### PR TITLE
fix: config file countdown counts from 20 to 0.

### DIFF
--- a/youtube_viewer.py
+++ b/youtube_viewer.py
@@ -985,7 +985,7 @@ if __name__ == '__main__':
             try:
                 i = 0
                 while i < 96:
-                    print(bcolors.OKBLUE + f"{time() - start:.0f} seconds remaining " +
+                    print(bcolors.OKBLUE + f"{20 - (time() - start):.0f} seconds remaining " +
                           animation[i % len(animation)] + bcolors.ENDC, end="\r")
                     i += 1
                     sleep(0.2)


### PR DESCRIPTION
Previously, the countdown start from 0 to 20 seconds remaining, which is counterintuitive.