### PR TITLE
Fixed edgecase on mac, download chromedriver = 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ patched_drivers/
 database.db
 database_backup.db
 config.json
-chromedriver.exe
+chromedriver*
 version.txt
 *.log

--- a/youtubeviewer/download_driver.py
+++ b/youtubeviewer/download_driver.py
@@ -28,7 +28,10 @@ import sys
 
 import undetected_chromedriver._compat as uc
 
-from .colors import *
+try:
+    from .colors import *
+except Exception:
+    from colors import *
 
 CHROME = ['{8A69D345-D564-463c-AFF1-A69D9E530F96}',
           '{8237E44A-0054-442C-B6B6-EA0509993955}',
@@ -104,10 +107,11 @@ def download_driver(patched_drivers):
             pass
 
         shutil.rmtree(patched_drivers, ignore_errors=True)
-
-    major_version = version.split('.')[0]
-
-    uc.TARGET_VERSION = major_version
+    
+    if osname != 'mac':
+        # these 2 lines break on my macbook
+        major_version = version.split('.')[0]
+        uc.TARGET_VERSION = major_version
 
     uc.install()
 

--- a/youtubeviewer/download_driver.py
+++ b/youtubeviewer/download_driver.py
@@ -28,10 +28,7 @@ import sys
 
 import undetected_chromedriver._compat as uc
 
-try:
-    from .colors import *
-except Exception:
-    from colors import *
+from .colors import *
 
 CHROME = ['{8A69D345-D564-463c-AFF1-A69D9E530F96}',
           '{8237E44A-0054-442C-B6B6-EA0509993955}',
@@ -108,10 +105,9 @@ def download_driver(patched_drivers):
 
         shutil.rmtree(patched_drivers, ignore_errors=True)
     
-    if osname != 'mac':
-        # these 2 lines break on my macbook
-        major_version = version.split('.')[0]
-        uc.TARGET_VERSION = major_version
+        # seems like the url naming convention has changed
+        #major_version = version.split('.')[0]
+        #uc.TARGET_VERSION = major_version
 
     uc.install()
 


### PR DESCRIPTION
When running youtube_viewer.py, my computer (MacOS 10.15.7) gave 404 errors from attempting to download the chrome driver. When debugging download_driver.py the colors import gave me trouble and that's why there's a try/catch block. gitignore file also wouldn't work with macs.

Thank you for your time.